### PR TITLE
Update/25 12 17 edit memory

### DIFF
--- a/include/Collector/GarbageCollector.h
+++ b/include/Collector/GarbageCollector.h
@@ -1,13 +1,17 @@
 #ifndef __MEMORY_GARBAGECOLLECTOR_H__
 #define __MEMORY_GARBAGECOLLECTOR_H__
 
-
 #include "TimeLimit.h"
 
 #include <Container/include/HashSet.h>
 #include <Container/include/DynamicArray.h>
 
 #include <mutex>
+
+namespace Reflection
+{
+	class PropertyInfo;
+};
 
 namespace Memory
 {
@@ -16,12 +20,20 @@ namespace Memory
 	class GarbageCollector
 	{
 		public :
-			enum eStatus : uint8_t
+			enum class eStatus : uint8_t
 			{
 				eIdle = 0,
 				eMarking = 1,
 				eSweeping = 2,
 				ePurging = 3,
+			};
+
+			enum class eDataType : uint8_t
+			{
+				eNone = 0,
+				eContainer = 1,
+				eStruct = 2,
+				eObject = 3
 			};
 
 		public :
@@ -41,6 +53,23 @@ namespace Memory
 			void Mark();
 			void Sweep();
 			void Purge();
+			
+			void MarkContainer(const void* rawProperty, const Reflection::PropertyInfo* propertyInfo, wtr::DynamicArray<const BasePtr*>& graphStack);
+			void MarkStruct(const void* rawProperty, const Reflection::PropertyInfo* propertyInfo, wtr::DynamicArray<const BasePtr*>& graphStack);
+			void MarkObject(const void* rawProperty, const Reflection::PropertyInfo* propertyInfo, wtr::DynamicArray<const BasePtr*>& graphStack);
+
+			/**
+			 * @brief	Check the property's data is possible to the GC marking.
+			 * @details	This function implements the checking the property's data that is possible the marking.
+			 *			The supported data type is the container, object, struct.
+			 *			The supported container types are the set, map, array(array, vector).
+			 *			The other containers(ex. stack, queue, deque, list) are not implemented yet.
+			 *			The struct type will be recursive calling marking for finding the object type.
+			 *			The object type that has the relation ship with BasePtr is the main role class in the GC.
+			 * @param	propertyInfo The reflected property's type.
+			 * @return	Return the property's data type for the GC marking.
+			*/
+			eDataType GetDataType(const Reflection::PropertyInfo* propertyInfo) const;
 
 		private :
 			wtr::HashSet<const BasePtr*> m_rootSet;

--- a/include/Pointer/BasePtr.h
+++ b/include/Pointer/BasePtr.h
@@ -18,10 +18,12 @@ namespace Memory
 
 		public :
 			virtual const Reflection::TypeInfo* GetPureType() const = 0;
+			virtual const Reflection::TypeInfo* GetRuntimeType() const = 0;
 			virtual const void* GetPointer() const = 0;
 			virtual void Mark() const = 0;
 			virtual void Unreachable() const = 0;
 			virtual bool IsMarked() const = 0;
+			virtual bool IsValid() const = 0;
 	};
 };
 

--- a/include/Pointer/BasePtr.h
+++ b/include/Pointer/BasePtr.h
@@ -21,6 +21,7 @@ namespace Memory
 			virtual const void* GetPointer() const = 0;
 			virtual void Mark() const = 0;
 			virtual void Unreachable() const = 0;
+			virtual bool IsMarked() const = 0;
 	};
 };
 

--- a/include/Pointer/ObjectPtr.h
+++ b/include/Pointer/ObjectPtr.h
@@ -49,11 +49,8 @@ namespace Memory
 			>
 			ObjectPtr& operator=(const ObjectPtr<U>& other)
 			{
-				if (this != &other)
-				{
-					m_accessor = other.m_accessor;
-					m_instance = static_cast<T*>(other.m_instance);
-				}
+				m_accessor = other.m_accessor;
+				m_instance = static_cast<T*>(other.m_instance);
 
 				return *this;
 			}
@@ -97,18 +94,31 @@ namespace Memory
 
 			explicit operator bool() const
 			{
-				return nullptr != m_accessor && nullptr != m_instance;
+				return IsValid();
 			}
 
 			bool operator!() const
 			{
-				return nullptr == m_accessor || nullptr == m_instance;
+				return !IsValid();
 			}
 
 		public :
 			const Reflection::TypeInfo* GetPureType() const override
 			{
 				return Reflection::TypeInfo::Get<T>();
+			}
+
+			const Reflection::TypeInfo* GetRuntimeType() const override
+			{
+				if (IsValid())
+				{
+					if constexpr (Reflection::Utils::HasRuntimeType<T>::value)
+					{
+						return m_instance->GetTypeInfo();
+					}
+				}
+
+				return GetPureType();
 			}
 
 			const void* GetPointer() const
@@ -121,7 +131,7 @@ namespace Memory
 				return m_accessor;
 			}
 
-			void Mark() const
+			void Mark() const override
 			{
 				if (nullptr != m_accessor)
 				{
@@ -129,7 +139,7 @@ namespace Memory
 				}
 			}
 
-			void Unreachable() const
+			void Unreachable() const override
 			{
 				if (nullptr != m_accessor)
 				{
@@ -137,16 +147,21 @@ namespace Memory
 				}
 			}
 
-			bool IsMakred() const
+			bool IsMarked() const override
 			{
 				if (nullptr != m_accessor)
 				{
-					return IAccessor::eStatus::eMakred == m_accessor->GetStatus();
+					return IAccessor::eStatus::eMarked == m_accessor->GetStatus();
 				}
 				else
 				{
 					return false;
 				}
+			}
+
+			bool IsValid() const override
+			{
+				return nullptr != m_accessor && nullptr != m_instance;
 			}
 
 		protected :

--- a/include/Pointer/ObjectPtr.h
+++ b/include/Pointer/ObjectPtr.h
@@ -95,6 +95,16 @@ namespace Memory
 				return m_instance;
 			}
 
+			explicit operator bool() const
+			{
+				return nullptr != m_accessor && nullptr != m_instance;
+			}
+
+			bool operator!() const
+			{
+				return nullptr == m_accessor || nullptr == m_instance;
+			}
+
 		public :
 			const Reflection::TypeInfo* GetPureType() const override
 			{
@@ -124,6 +134,18 @@ namespace Memory
 				if (nullptr != m_accessor)
 				{
 					m_accessor->SetStatus(IAccessor::eStatus::eUnreachable);
+				}
+			}
+
+			bool IsMakred() const
+			{
+				if (nullptr != m_accessor)
+				{
+					return IAccessor::eStatus::eMakred == m_accessor->GetStatus();
+				}
+				else
+				{
+					return false;
 				}
 			}
 

--- a/include/Storage/Array.h
+++ b/include/Storage/Array.h
@@ -96,6 +96,10 @@ namespace Memory
 
 					m_used = false;
 				}
+				else
+				{
+					accessor->SetStatus(IAccessor::eStatus::eUnreachable);
+				}
 			}
 
 			size_t GetChunkSize() const override

--- a/include/Storage/Pool.h
+++ b/include/Storage/Pool.h
@@ -165,6 +165,8 @@ namespace Memory
 					}
 					else
 					{
+						accessor->SetStatus(IAccessor::eStatus::eUnreachable);
+
 						itr++;
 					}
 				}

--- a/include/Storage/StorageManager.h
+++ b/include/Storage/StorageManager.h
@@ -37,27 +37,31 @@ namespace Memory
 			template<typename T, typename... Args>
 			Accessor<T>* Create(Args&&... args)
 			{
-				std::lock_guard<std::mutex> lock(m_mutex);
-
-				PoolBudget& poolBudget = GetPool<T>();
-				PoolBudget::PoolEntry poolEntry = poolBudget.GetPool();
-				if (nullptr == poolEntry.pool)
+				PoolBudget::PoolEntry poolEntry;
+				Accessor<T>* accessor = nullptr;
 				{
-					return nullptr;
-				}
+					std::lock_guard<std::mutex> lock(m_mutex);
 
-				Accessor<T>* accessor = static_cast<Accessor<T>*>(poolEntry.pool->Acquire());
-				if (nullptr == accessor)
-				{
-					return nullptr;
+					PoolBudget& poolBudget = GetPool<T>();
+					poolEntry = poolBudget.GetPool();
+					if (nullptr == poolEntry.pool)
+					{
+						return nullptr;
+					}
+
+					accessor = static_cast<Accessor<T>*>(poolEntry.pool->Acquire());
+					if (nullptr == accessor)
+					{
+						return nullptr;
+					}
+
+					if (poolBudget.CheckDensity(poolEntry))
+					{
+						poolBudget.UpdatePool(poolEntry);
+					}
 				}
 
 				accessor->Construct(std::forward<Args>(args)...);
-
-				if (poolBudget.CheckDensity(poolEntry))
-				{
-					poolBudget.UpdatePool(poolEntry);
-				}
 
 				return accessor;
 			}
@@ -65,20 +69,26 @@ namespace Memory
 			template<typename T, typename... Args>
 			Accessor<T>* CreateArray(const size_t count, Args&&... args)
 			{
-				std::lock_guard<std::mutex> lock(m_mutex);
+				ArrayBudget::ArrayEntry arrayEntry;
+				Accessor<T>* accessor = nullptr;
 
-				ArrayBudget& arrayBudget = GetArray<T>();
-				ArrayBudget::ArrayEntry arrayEntry = arrayBudget.GetArray(count);
-				if (nullptr == arrayEntry.array)
 				{
-					return nullptr;
+					std::lock_guard<std::mutex> lock(m_mutex);
+
+					ArrayBudget& arrayBudget = GetArray<T>();
+					arrayEntry = arrayBudget.GetArray(count);
+					if (nullptr == arrayEntry.array)
+					{
+						return nullptr;
+					}
+
+					accessor = static_cast<Accessor<T>*>(arrayEntry.array->Acquire());
+					if (nullptr == accessor)
+					{
+						return nullptr;
+					}
 				}
 
-				Accessor<T>* accessor = static_cast<Accessor<T>*>(arrayEntry.array->Acquire());
-				if (nullptr == accessor)
-				{
-					return nullptr;
-				}
 				accessor->Construct(std::forward<Args>(args)...);
 
 				return accessor;

--- a/include/TimeLimit.h
+++ b/include/TimeLimit.h
@@ -9,7 +9,7 @@ namespace Memory
 	{
 		public :
 			using Clock = std::chrono::high_resolution_clock;
-			using Duration = std::chrono::nanoseconds;
+			using Duration = std::chrono::milliseconds;
 
 		public :
 			TimeLimit();

--- a/src/Collector/GarbageCollector.cpp
+++ b/src/Collector/GarbageCollector.cpp
@@ -1,7 +1,7 @@
 #include "Collector/GarbageCollector.h"
 
-#include "Core.h"
 #include "Log/include/Log.h"
+#include "Core.h"
 
 #include <queue>
 
@@ -13,15 +13,16 @@ namespace Memory
 		, m_timeLimit()
 		, m_mutex()
 		, m_status(eStatus::eIdle)
-	{}
+	{
+		m_graphStack.Reserve(4096);
+		m_timeLimit.Init(100);
+	}
 
 	GarbageCollector::~GarbageCollector()
 	{}
 
 	void GarbageCollector::Init(const size_t sweepTime)
 	{
-		m_graphStack.Reserve(4096);
-
 		m_timeLimit.Init(sweepTime);
 	}
 
@@ -80,8 +81,6 @@ namespace Memory
 
 	void GarbageCollector::Mark()
 	{
-		static const Reflection::TypeInfo* baseType = Reflection::TypeInfo::Get<BasePtr>();
-
 		LOGINFO() << "[COLLECTOR] GC Cycle - Mark";
 
 		while (!m_graphStack.Empty())
@@ -89,98 +88,37 @@ namespace Memory
 			const BasePtr* basePtr = m_graphStack.Back();
 			m_graphStack.PopBack();
 
-			if (basePtr->IsMarked())
+			if (nullptr == basePtr || !basePtr->IsValid() || basePtr->IsMarked())
 			{
 				continue;
 			}
 
 			basePtr->Mark();
 
-			const Reflection::TypeInfo* pureType = basePtr->GetPureType();
-			const Reflection::TypeInfo::PropertyMap& properties = pureType->GetProperties();
+			const Reflection::TypeInfo* runtimeType = basePtr->GetRuntimeType();
+			const Reflection::TypeInfo::PropertyMap& properties = runtimeType->GetProperties();
 
 			const void* rawInstance = basePtr->GetPointer();
 
-			for (auto [name, property] : properties)
+			for (const auto& [name, propertyInfo] : properties)
 			{
-				const void* rawProperty = property->GetRaw(rawInstance);
+				const eDataType eType = GetDataType(propertyInfo);
+				const void* rawProperty = propertyInfo->GetRaw(rawInstance);
 
-				if (const Reflection::ArrayPropertyInfo* arrayProperty = Reflection::Cast<const Reflection::ArrayPropertyInfo*>(property))
+				if (eDataType::eContainer == eType)
 				{
-					const Reflection::TypeInfo* valueType = arrayProperty->GetValueType();
-					if (!Reflection::IsChild(baseType, valueType))
-					{
-						continue;
-					}
-
-					auto beginItr = arrayProperty->begin(rawProperty);
-					auto endItr = arrayProperty->end(rawProperty);
-					
-					for (auto itr = beginItr; itr != endItr; itr++)
-					{
-						const BasePtr* rawValue = static_cast<const BasePtr*>(itr.get());
-						m_graphStack.PushBack(rawValue);
-					}
+					MarkContainer(rawProperty, propertyInfo, m_graphStack);
 				}
-				else if (const Reflection::SetPropertyInfo* setProperty = Reflection::Cast<const Reflection::SetPropertyInfo*>(property))
+				else if (eDataType::eStruct == eType)
 				{
-					const Reflection::TypeInfo* valueType = setProperty->GetValueType();
-					if (!Reflection::IsChild(baseType, valueType))
-					{
-						continue;
-					}
-
-					auto beginItr = arrayProperty->begin(rawProperty);
-					auto endItr = arrayProperty->end(rawProperty);
-
-					for (auto itr = beginItr; itr != endItr; itr++)
-					{
-						const BasePtr* rawValue = static_cast<const BasePtr*>(itr.get());
-						m_graphStack.PushBack(rawValue);
-					}
+					MarkStruct(rawProperty, propertyInfo, m_graphStack);
 				}
-				else if (const Reflection::MapPropertyInfo* mapProperty = Reflection::Cast<const Reflection::MapPropertyInfo*>(property))
+				else if (eDataType::eObject == eType)
 				{
-					const Reflection::TypeInfo* keyType = mapProperty->GetKeyType();
-					const Reflection::TypeInfo* mappedType = mapProperty->GetMappedType();
-					
-					const bool keyMarked = Reflection::IsChild(baseType, keyType);
-					const bool mappedMarked = Reflection::IsChild(baseType, mappedType);
-					if (!keyMarked && !mappedMarked)
-					{
-						continue;
-					}
-
-					auto beginItr = mapProperty->begin(rawProperty);
-					auto endItr = mapProperty->end(rawProperty);
-
-					for (auto itr = beginItr; itr != endItr; itr++)
-					{
-						const void* rawValue = itr.get();
-						if (keyMarked)
-						{
-							const BasePtr* rawKey = static_cast<const BasePtr*>(mapProperty->GetRawKey(rawValue));
-							m_graphStack.PushBack(rawKey);
-						}
-
-						if (mappedMarked)
-						{
-							const BasePtr* rawMapped = static_cast<const BasePtr*>(mapProperty->GetRawMapped(rawValue));
-							m_graphStack.PushBack(rawMapped);
-						}
-					}
+					MarkObject(rawProperty, propertyInfo, m_graphStack);
 				}
 				else
-				{
-					const Reflection::TypeInfo* propertyType = property->GetPropertyType();
-					if (!Reflection::IsChild(baseType, propertyType))
-					{
-						continue;
-					}
-
-					const BasePtr* rawValue = static_cast<const BasePtr*>(rawProperty);
-					m_graphStack.PushBack(rawValue);
-				}
+				{}
 			}
 		}
 
@@ -212,5 +150,163 @@ namespace Memory
 		{
 			m_status = eStatus::ePurging;
 		}
+	}
+
+	void GarbageCollector::MarkContainer(const void* rawProperty, const Reflection::PropertyInfo* propertyInfo, wtr::DynamicArray<const BasePtr*>& graphStack)
+	{
+		static const Reflection::TypeInfo* baseType = Reflection::TypeInfo::Get<BasePtr>();
+
+		if (const Reflection::ArrayPropertyInfo* arrayProperty = Reflection::Cast<const Reflection::ArrayPropertyInfo*>(propertyInfo))
+		{
+			const Reflection::TypeInfo* valueType = arrayProperty->GetValueType();
+			if (!Reflection::IsChild(baseType, valueType))
+			{
+				return;
+			}
+
+			auto beginItr = arrayProperty->begin(rawProperty);
+			auto endItr = arrayProperty->end(rawProperty);
+
+			for (auto itr = beginItr; itr != endItr; itr++)
+			{
+				const BasePtr* rawValue = static_cast<const BasePtr*>(itr.get());
+				if (rawValue->IsValid())
+				{
+					graphStack.PushBack(rawValue);
+				}
+			}
+		}
+		else if (const Reflection::SetPropertyInfo* setProperty = Reflection::Cast<const Reflection::SetPropertyInfo*>(propertyInfo))
+		{
+			const Reflection::TypeInfo* valueType = setProperty->GetValueType();
+			if (!Reflection::IsChild(baseType, valueType))
+			{
+				return;
+			}
+
+			auto beginItr = setProperty->begin(rawProperty);
+			auto endItr = setProperty->end(rawProperty);
+
+			for (auto itr = beginItr; itr != endItr; itr++)
+			{
+				const BasePtr* rawValue = static_cast<const BasePtr*>(itr.get());
+				if (rawValue->IsValid())
+				{
+					graphStack.PushBack(rawValue);
+				}
+			}
+		}
+		else if (const Reflection::MapPropertyInfo* mapProperty = Reflection::Cast<const Reflection::MapPropertyInfo*>(propertyInfo))
+		{
+			const Reflection::TypeInfo* keyType = mapProperty->GetKeyType();
+			const Reflection::TypeInfo* mappedType = mapProperty->GetMappedType();
+
+			const bool keyMarked = Reflection::IsChild(baseType, keyType);
+			const bool mappedMarked = Reflection::IsChild(baseType, mappedType);
+			if (!keyMarked && !mappedMarked)
+			{
+				return;
+			}
+
+			auto beginItr = mapProperty->begin(rawProperty);
+			auto endItr = mapProperty->end(rawProperty);
+
+			for (auto itr = beginItr; itr != endItr; itr++)
+			{
+				const void* rawValue = itr.get();
+				if (keyMarked)
+				{
+					const BasePtr* rawKey = static_cast<const BasePtr*>(mapProperty->GetRawKey(rawValue));
+					if (rawKey->IsValid())
+					{
+						graphStack.PushBack(rawKey);
+					}
+				}
+
+				if (mappedMarked)
+				{
+					const BasePtr* rawMapped = static_cast<const BasePtr*>(mapProperty->GetRawMapped(rawValue));
+					if (rawMapped->IsValid())
+					{
+						graphStack.PushBack(rawMapped);
+					}
+				}
+			}
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	void GarbageCollector::MarkStruct(const void* rawProperty, const Reflection::PropertyInfo* propertyInfo, wtr::DynamicArray<const BasePtr*>& graphStack)
+	{
+		const Reflection::TypeInfo* propertyType = propertyInfo->GetPropertyType();
+		const Reflection::TypeInfo::PropertyMap& propertyMap = propertyType->GetProperties();
+
+		for (const auto& [name, memberInfo] : propertyMap)
+		{
+			const void* rawMember = memberInfo->GetRaw(rawProperty);
+
+			const eDataType eType = GetDataType(memberInfo);
+
+			if (eDataType::eContainer == eType)
+			{
+				MarkContainer(rawMember, memberInfo, graphStack);
+			}
+			else if (eDataType::eStruct == eType)
+			{
+				MarkStruct(rawMember, memberInfo, graphStack);
+			}
+			else if (eDataType::eObject == eType)
+			{
+				MarkObject(rawMember, memberInfo, graphStack);
+			}
+			else
+			{
+			}
+		}
+	}
+
+	void GarbageCollector::MarkObject(const void* rawProperty, const Reflection::PropertyInfo* propertyInfo, wtr::DynamicArray<const BasePtr*>& graphStack)
+	{
+		static const Reflection::TypeInfo* baseType = Reflection::TypeInfo::Get<BasePtr>();
+
+		const Reflection::TypeInfo* propertyType = propertyInfo->GetPropertyType();
+		if (!Reflection::IsChild(baseType, propertyType))
+		{
+			return;
+		}
+
+		const BasePtr* rawValue = static_cast<const BasePtr*>(rawProperty);
+		if (rawValue->IsValid())
+		{
+			graphStack.PushBack(rawValue);
+		}
+	}
+
+	GarbageCollector::eDataType GarbageCollector::GetDataType(const Reflection::PropertyInfo* propertyInfo) const
+	{
+		const Reflection::ContainerPropertyInfo* containerInfo = Reflection::Cast<const Reflection::ContainerPropertyInfo*>(propertyInfo);
+		if (nullptr != containerInfo)
+		{
+			return eDataType::eContainer;
+		}
+
+		const Reflection::TypeInfo* propertyType = propertyInfo->GetPropertyType();
+		const Reflection::TypeInfo* baseType = Reflection::TypeInfo::Get<BasePtr>();
+
+		if (Reflection::IsChild(baseType, propertyType))
+		{
+			return eDataType::eObject;
+		}
+
+		const Reflection::TypeInfo::PropertyMap& propertyMap = propertyType->GetProperties();
+		if (!propertyMap.empty())
+		{
+			return eDataType::eStruct;
+		}
+
+		return eDataType::eNone;
 	}
 };

--- a/src/Collector/GarbageCollector.cpp
+++ b/src/Collector/GarbageCollector.cpp
@@ -89,6 +89,11 @@ namespace Memory
 			const BasePtr* basePtr = m_graphStack.Back();
 			m_graphStack.PopBack();
 
+			if (basePtr->IsMarked())
+			{
+				continue;
+			}
+
 			basePtr->Mark();
 
 			const Reflection::TypeInfo* pureType = basePtr->GetPureType();

--- a/src/Storage/PoolBudget.cpp
+++ b/src/Storage/PoolBudget.cpp
@@ -57,7 +57,7 @@ namespace Memory
 		for (size_t index = 0; index <= endIndex; index++)
 		{
 			auto& poolList = m_poolList[index];
-			if (!poolList.Empty())
+			if (poolList.Empty())
 			{
 				empty = true;
 
@@ -65,7 +65,7 @@ namespace Memory
 			}
 		}
 
-		if (empty)
+		if (!empty)
 		{
 			Release();
 		}

--- a/src/Storage/StorageManager.cpp
+++ b/src/Storage/StorageManager.cpp
@@ -8,7 +8,7 @@ namespace Memory
 	StorageManager::StorageManager()
 		: m_poolMap()
 		, m_arrayMap()
-		, m_poolSize(512)
+		, m_poolSize(1024)
 	{}
 
 	StorageManager::~StorageManager()

--- a/src/TimeLimit.cpp
+++ b/src/TimeLimit.cpp
@@ -45,7 +45,7 @@ namespace Memory
 			}
 			else
 			{
-				m_current -= timeDuration;
+				m_current -= std::chrono::duration_cast<Duration>(timeDuration);
 			}
 
 			m_startTime = currentTime;


### PR DESCRIPTION
[Desc]
 - ** Fix ** the dead code elimination was occured in the gcc compiler on the template class that used the property and method macro.
Add the "used" macro keyword in the property and method's static variable that make the property info and method info.
But, this solution is not perfect, so, needs to find the right solution.
 - Add the Getter the property and method info from the super type.
So, if the properties and methods are same as super's things,
the hash(used the object's name) will be same and fail to add the type info.
So, Add the class name function in the utils file.
The file helps the type info get the real name and the property and method add the keyword that is the type name in front of the their name.
 - Fix the container property info's getter function for the mapped type. (m_keyType -> m_mappedType)
[Type/Branch]
[Auther/Data]