### PR TITLE
[Title] Edit the object and reference pointer

### DIFF
--- a/include/Core.h
+++ b/include/Core.h
@@ -34,7 +34,7 @@ namespace Memory
 	template<typename T, typename... Args>
 	RefPtr<T> MakeRef(Args&&... args)
 	{
-		RefPtr<T> ref = new T(std::forward<Args>(args)...);
+		RefPtr<T> ref = new RefData<T>(std::forward<Args>(args)...);
 
 		return ref;
 	}

--- a/include/Pointer/ObjectPtr.h
+++ b/include/Pointer/ObjectPtr.h
@@ -18,6 +18,7 @@ namespace Memory
 		public :
 			ObjectPtr()
 				: m_accessor(nullptr)
+				, m_instance(nullptr)
 			{}
 
 			ObjectPtr(const IAccessor* accessor)

--- a/include/Pointer/RefPtr.h
+++ b/include/Pointer/RefPtr.h
@@ -40,43 +40,67 @@ namespace Memory
 	};
 
 	template<typename T>
+	class RefPtr;
+
+	template<typename T>
+	class RefData : public RefCounted
+	{
+	public :
+		template<typename... Args>
+		RefData(Args&&... args)
+			: RefCounted()
+			, m_instance(std::forward<Args>(args)...)
+		{}
+
+	private :
+		template<typename U>
+		friend class RefPtr;
+
+		T m_instance;
+	};
+
+	template<typename T>
 	class RefPtr
 	{
 	public:
 		RefPtr()
 			: m_refInstance(nullptr)
-		{
-			static_assert(Reflection::Utils::IsBase<RefCounted, T>::value && "The invalid type for the reference pointer");
-		}
+			, m_refCounted(nullptr)
+		{}
 
-		RefPtr(T* refInstance)
-			: m_refInstance(refInstance)
-		{
-			static_assert(Reflection::Utils::IsBase<RefCounted, T>::value && "The invalid type for the reference pointer");
+		RefPtr(std::nullptr_t)
+			: m_refInstance(nullptr)
+			, m_refCounted(nullptr)
+		{}
 
-			if (nullptr != m_refInstance)
+		template<typename U>
+		RefPtr(RefData<U>* refData)
+			: m_refInstance(nullptr)
+			, m_refCounted(refData)
+		{
+			if (nullptr != refData)
 			{
-				m_refInstance->AddRef();
+				m_refInstance = static_cast<T*>(&refData->m_instance);
+				refData->AddRef();
 			}
 		}
 
 		RefPtr(const RefPtr& other)
 			: m_refInstance(other.m_refInstance)
+			, m_refCounted(other.m_refCounted)
 		{
-			static_assert(Reflection::Utils::IsBase<RefCounted, T>::value && "The invalid type for the reference pointer");
-
-			if (nullptr != m_refInstance)
+			if (nullptr != m_refCounted)
 			{
-				m_refInstance->AddRef();
+				m_refCounted->AddRef();
 			}
 		}
 
 		RefPtr(RefPtr&& other) noexcept
 			: m_refInstance(other.m_refInstance)
+			, m_refCounted(other.m_refCounted)
 		{
-			static_assert(Reflection::Utils::IsBase<RefCounted, T>::value && "The invalid type for the reference pointer");
-			
 			other.m_refInstance = nullptr;
+			other.m_refCounted = nullptr;
 		}
 
 		~RefPtr()
@@ -84,17 +108,22 @@ namespace Memory
 			Reset();
 		}
 
+		RefPtr& operator=(std::nullptr_t)
+		{
+			Reset();
+			
+			return *this;
+		}
+
 		RefPtr& operator=(const RefPtr& other)
 		{
-			if (this != &other)
-			{
-				Reset();
+			Reset();
 
-				m_refInstance = other.m_refInstance;
-				if (nullptr != m_refInstance)
-				{
-					m_refInstance->AddRef();
-				}
+			m_refInstance = other.m_refInstance;
+			m_refCounted = other.m_refCounted;
+			if (nullptr != m_refCounted)
+			{
+				m_refCounted->AddRef();
 			}
 
 			return *this;
@@ -102,13 +131,12 @@ namespace Memory
 
 		RefPtr& operator=(RefPtr&& other) noexcept
 		{
-			if (this != &other)
-			{
-				Reset();
+			Reset();
 
-				m_refInstance = other.m_refInstance;
-				other.m_refInstance = nullptr;
-			}
+			m_refInstance = other.m_refInstance;
+			m_refCounted = other.m_refCounted;
+			other.m_refInstance = nullptr;
+			other.m_refCounted = nullptr;
 
 			return *this;
 		}
@@ -117,11 +145,12 @@ namespace Memory
 			typename = Reflection::Utils::IsEnabled_t<
 			Reflection::Utils::IsSame<T, U>::value || Reflection::Utils::IsBase<T, U>::value>>
 		RefPtr(const RefPtr<U>& other)
-			: m_refInstance(other.m_refInstance)
+			: m_refInstance(static_cast<T*>(other.m_refInstance))
+			, m_refCounted(other.m_refCounted)
 		{
-			if (nullptr != m_refInstance)
+			if (nullptr != m_refCounted)
 			{
-				m_refInstance->AddRef();
+				m_refCounted->AddRef();
 			}
 		}
 
@@ -129,9 +158,11 @@ namespace Memory
 			typename = Reflection::Utils::IsEnabled_t<
 			Reflection::Utils::IsSame<T, U>::value || Reflection::Utils::IsBase<T, U>::value>>
 		RefPtr(RefPtr<U>&& other) noexcept
-			: m_refInstance(other.m_refInstance)
+			: m_refInstance(static_cast<T*>(other.m_refInstance))
+			, m_refCounted(other.m_refCounted)
 		{
 			other.m_refInstance = nullptr;
+			other.m_refCounted = nullptr;
 		}
 
 		template<typename U,
@@ -139,13 +170,12 @@ namespace Memory
 			Reflection::Utils::IsSame<T, U>::value || Reflection::Utils::IsBase<T, U>::value>>
 		RefPtr& operator=(const RefPtr<U>& other)
 		{
-			if (this != &other)
+			m_refInstance = static_cast<T*>(other.m_refInstance);
+			m_refCounted = other.m_refCounted;
+
+			if (nullptr != m_refCounted)
 			{
-				m_refInstance = other.m_refInstance;
-				if (nullptr != m_refInstance)
-				{
-					m_refInstance->AddRef();
-				}
+				m_refCounted->AddRef();
 			}
 
 			return *this;
@@ -156,24 +186,51 @@ namespace Memory
 			Reflection::Utils::IsSame<T, U>::value || Reflection::Utils::IsBase<T, U>::value>>
 		RefPtr& operator=(RefPtr<U>&& other) noexcept
 		{
-			if (this != &other)
-			{
-				m_refInstance = other.m_refInstance;
-				other.m_refInstance = nullptr;
-			}
+			m_refInstance = static_cast<T*>(other.m_refInstance);
+			m_refCounted = other.m_refCounted;
+			other.m_refInstance = nullptr;
+			other.m_refCounted = nullptr;
 
 			return *this;
+		}
+
+		bool operator==(const RefPtr& other)
+		{
+			return m_refInstance == other.m_refInstance && m_refCounted == other.m_refCounted;
+		}
+
+		bool operator!=(const RefPtr& other)
+		{
+			return !(this->operator==(other));
+		}
+
+		template<typename U,
+			typename = Reflection::Utils::IsEnabled_t<
+			Reflection::Utils::IsSame<T, U>::value || Reflection::Utils::IsBase<T, U>::value>>
+		bool operator==(const RefPtr<U>& other)
+		{
+			return m_refInstance == static_cast<T*>(other.m_refInstance) && m_refCounted == other.m_refCounted;
+		}
+
+		template<typename U,
+			typename = Reflection::Utils::IsEnabled_t<
+			Reflection::Utils::IsSame<T, U>::value || Reflection::Utils::IsBase<T, U>::value>>
+		bool operator!=(const RefPtr<U>& other)
+		{
+			return !(this->operator==(other));
 		}
 
 	public :
 		T* operator->() const
 		{
+			assert(nullptr != m_refInstance && "The reference data is invalid");
+
 			return m_refInstance;
 		}
 
 		T& operator*() const
 		{
-			assert(nullptr != m_refInstance && "The reference instance is invalid");
+			assert(nullptr != m_refInstance && "The reference data is invalid");
 
 			return *m_refInstance;
 		}
@@ -185,20 +242,26 @@ namespace Memory
 
 		bool operator!() const
 		{
-			return nullptr == m_refInstance;
+			return !(this->operator bool());
 		}
 
 		void Reset()
 		{
-			if (nullptr != m_refInstance)
+			if (nullptr != m_refCounted)
 			{
-				m_refInstance->Release();
-				m_refInstance = nullptr;
+				m_refCounted->Release();
+				m_refCounted = nullptr;
 			}
+
+			m_refInstance = nullptr;
 		}
 
 	private:
+		template<typename U>
+		friend class RefPtr;
+
 		T* m_refInstance;
+		RefCounted* m_refCounted;
 	};
 };
 


### PR DESCRIPTION
[Desc]
- The default constructor of the ObjectPtr couldn't initialize the instance's pointer to the nullptr, so, the runtime error was occured.
- The previous reference pointer must be inheritance the RefCounted, but, this class architecture is very difficult to use the reference pointer. so, edit the reference pointer simialiy to the standard shared pointer [Type/Branch]
[Auther/Data] Winteraio - 25/12/15